### PR TITLE
C'era un riferimento in path relativo.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,8 @@ dependencies:
   path_provider: any
 
   easy_widget:
-    path: ../easy_packages
+    git:
+      url: git://github.com/BreX900/easy_widget.git
 
   json_annotation: any
 


### PR DESCRIPTION
Il plugin easy_widget era implementato in locale, l'ho aggiornato ad una referenza al plugin online, se no non è possibile implementare questo plugin da GitHub.